### PR TITLE
feat: CB込み利益（見込み・実現）の計算と表示を追加

### DIFF
--- a/src/components/dashboard/monthly-summary-table.tsx
+++ b/src/components/dashboard/monthly-summary-table.tsx
@@ -83,6 +83,16 @@ export function MonthlySummaryTable({ year, rows }: Props) {
       cell: ({ row }) => formatCurrency(row.original.actualProfit),
     },
     {
+      accessorKey: "expectedProfitWithCb",
+      header: "見込み利益(CB込)",
+      cell: ({ row }) => formatCurrency(row.original.expectedProfitWithCb),
+    },
+    {
+      accessorKey: "actualProfitWithCb",
+      header: "実現利益(CB込)",
+      cell: ({ row }) => formatCurrency(row.original.actualProfitWithCb),
+    },
+    {
       accessorKey: "profitRate",
       header: "利益率",
       cell: ({ row }) =>

--- a/src/components/events/event-detail.tsx
+++ b/src/components/events/event-detail.tsx
@@ -188,6 +188,14 @@ export function EventDetail({ event }: Props) {
                             <dd className="mt-1 text-lg font-semibold">{formatYen(event.financials.actualProfit)}</dd>
                         </div>
                         <div>
+                            <dt className="text-sm font-medium text-muted-foreground">見込み利益(CB込)</dt>
+                            <dd className="mt-1 text-lg font-semibold">{formatYen(event.financials.expectedProfitWithCb)}</dd>
+                        </div>
+                        <div>
+                            <dt className="text-sm font-medium text-muted-foreground">実現利益(CB込)</dt>
+                            <dd className="mt-1 text-lg font-semibold">{formatYen(event.financials.actualProfitWithCb)}</dd>
+                        </div>
+                        <div>
                             <dt className="text-sm font-medium text-muted-foreground">利益率</dt>
                             <dd className="mt-1 text-lg font-semibold">
                                 {event.financials.profitRate !== null

--- a/src/components/reports/report-table.tsx
+++ b/src/components/reports/report-table.tsx
@@ -86,6 +86,16 @@ export function ReportTable({ data }: Props) {
       cell: ({ row }) => formatCurrency(row.original.actualProfit),
     },
     {
+      accessorKey: "expectedProfitWithCb",
+      header: "見込み利益(CB込)",
+      cell: ({ row }) => formatCurrency(row.original.expectedProfitWithCb),
+    },
+    {
+      accessorKey: "actualProfitWithCb",
+      header: "実現利益(CB込)",
+      cell: ({ row }) => formatCurrency(row.original.actualProfitWithCb),
+    },
+    {
       accessorKey: "profitRate",
       header: "利益率",
       cell: ({ row }) =>

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -8,7 +8,7 @@ import type { FinancialSummary } from "@/types";
  * 参加者の個別参加費は決済済み収入の計算にのみ使用する。
  */
 export function calculateEventFinancials(
-    event: { maleFee: number; femaleFee: number; venueCost: number },
+    event: { maleFee: number; femaleFee: number; venueCost: number; expectedCashback: number; actualCashback: number },
     participants: {
         gender: Gender;
         fee: number;
@@ -43,6 +43,10 @@ export function calculateEventFinancials(
     // 実現利益
     const actualProfit = paidRevenue - event.venueCost;
 
+    // CB込み利益
+    const expectedProfitWithCb = expectedProfit + event.expectedCashback;
+    const actualProfitWithCb = actualProfit + event.actualCashback;
+
     // 利益率（見込）— 小数第2位まで
     const profitRate =
         expectedRevenue > 0
@@ -60,6 +64,8 @@ export function calculateEventFinancials(
         uncollected,
         expectedProfit,
         actualProfit,
+        expectedProfitWithCb,
+        actualProfitWithCb,
         profitRate,
     };
 }

--- a/src/queries/dashboard-queries.ts
+++ b/src/queries/dashboard-queries.ts
@@ -32,6 +32,8 @@ export async function getMonthlySummary(
     uncollected: 0,
     expectedProfit: 0,
     actualProfit: 0,
+    expectedProfitWithCb: 0,
+    actualProfitWithCb: 0,
     profitRate: null,
     matchCount: 0,
   }));
@@ -52,6 +54,8 @@ export async function getMonthlySummary(
     row.uncollected += financials.uncollected;
     row.expectedProfit += financials.expectedProfit;
     row.actualProfit += financials.actualProfit;
+    row.expectedProfitWithCb += financials.expectedProfitWithCb;
+    row.actualProfitWithCb += financials.actualProfitWithCb;
   }
 
   // 月ごとの利益率を計算

--- a/src/queries/event-queries.ts
+++ b/src/queries/event-queries.ts
@@ -24,6 +24,8 @@ export type ReportRow = {
   uncollected: number;
   expectedProfit: number;
   actualProfit: number;
+  expectedProfitWithCb: number;
+  actualProfitWithCb: number;
   profitRate: number | null;
 };
 
@@ -139,6 +141,8 @@ export async function getReportData(options: {
       uncollected: financials.uncollected,
       expectedProfit: financials.expectedProfit,
       actualProfit: financials.actualProfit,
+      expectedProfitWithCb: financials.expectedProfitWithCb,
+      actualProfitWithCb: financials.actualProfitWithCb,
       profitRate: financials.profitRate,
     };
   });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,8 @@ export type FinancialSummary = {
   uncollected: number;
   expectedProfit: number;
   actualProfit: number;
+  expectedProfitWithCb: number;
+  actualProfitWithCb: number;
   profitRate: number | null;
 };
 
@@ -49,6 +51,8 @@ export type MonthlySummaryRow = {
   uncollected: number;
   expectedProfit: number;
   actualProfit: number;
+  expectedProfitWithCb: number;
+  actualProfitWithCb: number;
   profitRate: number | null;
   matchCount: number;
 };

--- a/tests/integration/queries.test.ts
+++ b/tests/integration/queries.test.ts
@@ -228,7 +228,7 @@ describe("Participant Queries (Integration)", () => {
 
     const detail = await getEventDetail(event.eventId);
     const expected = calculateEventFinancials(
-      { maleFee: event.maleFee, femaleFee: event.femaleFee, venueCost: event.venueCost },
+      { maleFee: event.maleFee, femaleFee: event.femaleFee, venueCost: event.venueCost, expectedCashback: event.expectedCashback, actualCashback: event.actualCashback },
       participantsData
     );
 

--- a/tests/unit/calculations.test.ts
+++ b/tests/unit/calculations.test.ts
@@ -4,7 +4,7 @@ import { calculateEventFinancials } from "@/lib/calculations";
 describe("calculateEventFinancials", () => {
     // CALC-001: 男女各3名、全員未決済
     it("CALC-001: 男女各3名・全員未決済で正しい収支を返す", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 6000, paymentStatus: "UNPAID" as const, isDeleted: false },
             { gender: "MALE" as const, fee: 6000, paymentStatus: "UNPAID" as const, isDeleted: false },
@@ -31,7 +31,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-002: 男女各3名、全員決済済
     it("CALC-002: 全員決済済で正しい収支を返す", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
             { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
@@ -52,7 +52,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-003: 一部決済済（男2名済、女1名済）
     it("CALC-003: 一部決済済で正しい収支を返す", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
             { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
@@ -73,7 +73,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-004: 参加者0名
     it("CALC-004: 参加者0名で全カウント0・profitRateがnull", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000, expectedCashback: 0, actualCashback: 0 };
         const participants: { gender: "MALE" | "FEMALE"; fee: number; paymentStatus: "PAID" | "UNPAID"; isDeleted: boolean }[] = [];
 
         const result = calculateEventFinancials(event, participants);
@@ -90,7 +90,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-005: 見込み収入0円で利益率はnull（ゼロ除算回避）
     it("CALC-005: 見込み収入0円でprofitRateがnull", () => {
-        const event = { maleFee: 0, femaleFee: 0, venueCost: 10000 };
+        const event = { maleFee: 0, femaleFee: 0, venueCost: 10000, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 0, paymentStatus: "PAID" as const, isDeleted: false },
         ];
@@ -103,7 +103,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-006: 参加費0円の参加者
     it("CALC-006: 参加費0円の参加者でpaidRevenue=0", () => {
-        const event = { maleFee: 0, femaleFee: 0, venueCost: 0 };
+        const event = { maleFee: 0, femaleFee: 0, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 0, paymentStatus: "PAID" as const, isDeleted: false },
         ];
@@ -115,7 +115,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-007: 個別参加費とイベント標準レートが異なる場合
     it("CALC-007: 個別参加費とイベント標準レートが異なる場合、見込み収入はイベント標準レートで計算", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 5000, paymentStatus: "PAID" as const, isDeleted: false },
         ];
@@ -128,7 +128,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-008: 決済済み収入が見込み収入を超える場合
     it("CALC-008: 決済済み収入が見込み収入を超える場合、uncollectedが負値", () => {
-        const event = { maleFee: 5000, femaleFee: 4000, venueCost: 0 };
+        const event = { maleFee: 5000, femaleFee: 4000, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 7000, paymentStatus: "PAID" as const, isDeleted: false },
         ];
@@ -142,7 +142,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-009: 論理削除された参加者は集計から除外
     it("CALC-009: 論理削除された参加者は集計から除外", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
             { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
@@ -158,7 +158,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-010: 会場費0円
     it("CALC-010: 会場費0円で見込み利益=見込み収入", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
             { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
@@ -177,7 +177,7 @@ describe("calculateEventFinancials", () => {
 
     // CALC-011: 利益率の小数精度
     it("CALC-011: 利益率が小数第2位まで正確", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 6000, paymentStatus: "UNPAID" as const, isDeleted: false },
             { gender: "MALE" as const, fee: 6000, paymentStatus: "UNPAID" as const, isDeleted: false },
@@ -194,9 +194,45 @@ describe("calculateEventFinancials", () => {
         expect(result.profitRate).toBe(33.33);
     });
 
+    // CALC-CB-001: CB込み利益が正しく計算されること
+    it("CALC-CB-001: CB込み利益が正しく計算される", () => {
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000, expectedCashback: 3000, actualCashback: 2500 };
+        const participants = [
+            { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
+            { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
+            { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
+            { gender: "FEMALE" as const, fee: 4000, paymentStatus: "PAID" as const, isDeleted: false },
+            { gender: "FEMALE" as const, fee: 4000, paymentStatus: "PAID" as const, isDeleted: false },
+            { gender: "FEMALE" as const, fee: 4000, paymentStatus: "PAID" as const, isDeleted: false },
+        ];
+
+        const result = calculateEventFinancials(event, participants);
+
+        // expectedProfit = 30000 - 20000 = 10000
+        // expectedProfitWithCb = 10000 + 3000 = 13000
+        expect(result.expectedProfitWithCb).toBe(13000);
+        // actualProfit = 30000 - 20000 = 10000
+        // actualProfitWithCb = 10000 + 2500 = 12500
+        expect(result.actualProfitWithCb).toBe(12500);
+    });
+
+    // CALC-CB-002: CB=0の場合、CB込み利益 = CB無し利益
+    it("CALC-CB-002: CB=0の場合、CB込み利益はCB無し利益と一致する", () => {
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 20000, expectedCashback: 0, actualCashback: 0 };
+        const participants = [
+            { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
+            { gender: "FEMALE" as const, fee: 4000, paymentStatus: "PAID" as const, isDeleted: false },
+        ];
+
+        const result = calculateEventFinancials(event, participants);
+
+        expect(result.expectedProfitWithCb).toBe(result.expectedProfit);
+        expect(result.actualProfitWithCb).toBe(result.actualProfit);
+    });
+
     // CALC-012: 男性のみ / 女性のみのイベント
     it("CALC-012: 男性のみのイベントで正しい収支を返す", () => {
-        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0 };
+        const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
         const participants = [
             { gender: "MALE" as const, fee: 6000, paymentStatus: "UNPAID" as const, isDeleted: false },
             { gender: "MALE" as const, fee: 6000, paymentStatus: "UNPAID" as const, isDeleted: false },

--- a/tests/unit/edge-cases.test.ts
+++ b/tests/unit/edge-cases.test.ts
@@ -4,7 +4,7 @@ import { calculateEventFinancials } from "@/lib/calculations";
 describe("Edge Cases (Unit)", () => {
   // EDGE-002: 参加費0円の登録・集計
   it("EDGE-002: 参加費0円の参加者で正常に集計される", () => {
-    const event = { maleFee: 0, femaleFee: 0, venueCost: 0 };
+    const event = { maleFee: 0, femaleFee: 0, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
     const participants = [
       { gender: "MALE" as const, fee: 0, paymentStatus: "PAID" as const, isDeleted: false },
     ];
@@ -19,7 +19,7 @@ describe("Edge Cases (Unit)", () => {
 
   // EDGE-003: 見込み収入0円で利益率計算（ゼロ除算回避）
   it("EDGE-003: 見込み収入0円でprofitRateがnull（ゼロ除算なし）", () => {
-    const event = { maleFee: 0, femaleFee: 0, venueCost: 5000 };
+    const event = { maleFee: 0, femaleFee: 0, venueCost: 5000, expectedCashback: 0, actualCashback: 0 };
     const participants = [
       { gender: "MALE" as const, fee: 0, paymentStatus: "UNPAID" as const, isDeleted: false },
     ];
@@ -34,7 +34,7 @@ describe("Edge Cases (Unit)", () => {
   // EDGE-007: 空文字の氏名検索（ユニット観点 — 計算ロジックには直接関係ないが境界値確認）
   it("EDGE-007: 空文字フィルタはビジネスロジック層では問題なし", () => {
     // 空文字フィルタは queries 層で処理されるが、計算関数は影響を受けない
-    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0 };
+    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
     const participants = [
       { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
       { gender: "FEMALE" as const, fee: 4000, paymentStatus: "UNPAID" as const, isDeleted: false },
@@ -47,7 +47,7 @@ describe("Edge Cases (Unit)", () => {
 
   // EDGE-009: イベント日付が月初（1日）
   it("EDGE-009: 月初日付でもcalculateEventFinancialsが正常動作する", () => {
-    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 10000 };
+    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 10000, expectedCashback: 0, actualCashback: 0 };
     const participants = [
       { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
     ];
@@ -60,7 +60,7 @@ describe("Edge Cases (Unit)", () => {
 
   // EDGE-010: イベント日付が月末（31日）
   it("EDGE-010: 月末日付でも正常に計算される", () => {
-    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 10000 };
+    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 10000, expectedCashback: 0, actualCashback: 0 };
     const participants = [
       { gender: "FEMALE" as const, fee: 4000, paymentStatus: "UNPAID" as const, isDeleted: false },
     ];
@@ -73,7 +73,7 @@ describe("Edge Cases (Unit)", () => {
 
   // EDGE-011: うるう年2月29日
   it("EDGE-011: うるう年2月29日でも正常に計算される", () => {
-    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0 };
+    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 0, expectedCashback: 0, actualCashback: 0 };
     const participants = [
       { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: false },
     ];
@@ -86,7 +86,7 @@ describe("Edge Cases (Unit)", () => {
 
   // EDGE-013: 参加者全員論理削除された場合の収支
   it("EDGE-013: 参加者全員が論理削除された場合、totalCount=0、expectedRevenue=0", () => {
-    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 10000 };
+    const event = { maleFee: 6000, femaleFee: 4000, venueCost: 10000, expectedCashback: 0, actualCashback: 0 };
     const participants = [
       { gender: "MALE" as const, fee: 6000, paymentStatus: "PAID" as const, isDeleted: true },
       { gender: "FEMALE" as const, fee: 4000, paymentStatus: "PAID" as const, isDeleted: true },


### PR DESCRIPTION
既存の利益計算を変更せず、expectedProfitWithCb / actualProfitWithCb を 別項目として追加。イベント詳細・ダッシュボード月別サマリー・収支レポートの
3画面に新カラムを表示し、CB有無の比較を可能にした。