### PR TITLE
fix(ci): Claude Code Action の OIDC 認証エラーを修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,6 +14,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}


### PR DESCRIPTION
permissions に id-token: write を追加し、Claude GitHub App が OIDC トークンを取得できるようにする。