### PR TITLE
feat: LINE募集メッセージの改良

### DIFF
--- a/src/components/schedule/line-text-dialog.tsx
+++ b/src/components/schedule/line-text-dialog.tsx
@@ -24,6 +24,7 @@ type Props = {
     femaleFee: number;
     theme: string | null;
     targetOccupation: string | null;
+    mapUrl: string | null;
   };
   currentParticipants: {
     maleCount: number;

--- a/src/components/schedule/schedule-table.tsx
+++ b/src/components/schedule/schedule-table.tsx
@@ -156,6 +156,7 @@ export function ScheduleTable({ events }: Props) {
               femaleFee: row.original.femaleFee,
               theme: row.original.theme,
               targetOccupation: row.original.targetOccupation,
+              mapUrl: row.original.mapUrl,
             }}
             currentParticipants={{ maleCount, femaleCount }}
           >

--- a/src/lib/line-text.ts
+++ b/src/lib/line-text.ts
@@ -17,6 +17,7 @@ export function generateLineText(
     femaleFee: number;
     theme: string | null;
     targetOccupation: string | null;
+    mapUrl: string | null;
   },
   currentParticipants: {
     maleCount: number;
@@ -30,24 +31,33 @@ export function generateLineText(
   const femaleRemaining = event.femaleCapacity - currentParticipants.femaleCount;
 
   const lines: string[] = [
-    `📅 ${dateStr}（${dayOfWeek}）`,
-    `⏰ ${event.startTime}〜`,
-    `📍 ${event.area} / ${event.venueName}`,
-    `👫 男性${event.maleCapacity}名 / 女性${event.femaleCapacity}名`,
-    `💰 男性 ${event.maleFee.toLocaleString()}円 / 女性 ${event.femaleFee.toLocaleString()}円`,
+    "飲み会のお知らせ",
+    "",
+    `${dateStr}（${dayOfWeek}）`,
+    `${event.startTime}〜`,
+    `${event.area} / ${event.venueName}`,
   ];
 
+  if (event.mapUrl) {
+    lines.push(event.mapUrl);
+  }
+
+  lines.push(
+    `男性${event.maleCapacity}名 / 女性${event.femaleCapacity}名`,
+    `男性 ${event.maleFee.toLocaleString()}円 / 女性 ${event.femaleFee.toLocaleString()}円`
+  );
+
   if (event.theme) {
-    lines.push(`🎯 テーマ: ${event.theme}`);
+    lines.push(`テーマ: ${event.theme}`);
   }
 
   if (event.targetOccupation) {
-    lines.push(`💼 対象: ${event.targetOccupation}`);
+    lines.push(`対象: ${event.targetOccupation}`);
   }
 
   const maleSlot = `男性${formatRemainingSlot(maleRemaining)}`;
   const femaleSlot = `女性${formatRemainingSlot(femaleRemaining)}`;
-  lines.push(`✅ 残枠: ${maleSlot} / ${femaleSlot}`);
+  lines.push(`残枠: ${maleSlot} / ${femaleSlot}`);
 
   return lines.join("\n");
 }

--- a/tests/unit/line-text.test.ts
+++ b/tests/unit/line-text.test.ts
@@ -12,6 +12,7 @@ const baseEvent = {
   femaleFee: 4000,
   theme: "春の出会い" as string | null,
   targetOccupation: "IT系" as string | null,
+  mapUrl: "https://maps.google.com/example" as string | null,
 };
 
 const baseParticipants = { maleCount: 2, femaleCount: 3 };
@@ -21,14 +22,17 @@ describe("generateLineText", () => {
   it("LINE-001: 全フィールド入力で固定順序のテキストが生成される", () => {
     const text = generateLineText(baseEvent, baseParticipants);
 
-    expect(text).toContain("📅");
-    expect(text).toContain("⏰");
-    expect(text).toContain("📍");
-    expect(text).toContain("👫");
-    expect(text).toContain("💰");
-    expect(text).toContain("🎯");
-    expect(text).toContain("💼");
-    expect(text).toContain("✅");
+    expect(text).toContain("飲み会のお知らせ");
+    expect(text).toContain("2025年3月15日（土）");
+    expect(text).toContain("19:00〜");
+    expect(text).toContain("渋谷 / ダイニングバーABC");
+    expect(text).toContain("男性5名 / 女性5名");
+    expect(text).toContain("男性 6,000円 / 女性 4,000円");
+    expect(text).toContain("テーマ: 春の出会い");
+    expect(text).toContain("対象: IT系");
+    expect(text).toContain("残枠:");
+    // 絵文字が含まれないこと
+    expect(text).not.toMatch(/[📅⏰📍👫💰🎯💼✅]/);
   });
 
   // LINE-002: 曜日の自動算出
@@ -59,14 +63,14 @@ describe("generateLineText", () => {
   it("LINE-006: テーマがnullの場合テーマ行が省略される", () => {
     const event = { ...baseEvent, theme: null };
     const text = generateLineText(event, baseParticipants);
-    expect(text).not.toContain("🎯");
+    expect(text).not.toContain("テーマ:");
   });
 
   // LINE-007: 対象職業がnull
   it("LINE-007: 対象職業がnullの場合職業行が省略される", () => {
     const event = { ...baseEvent, targetOccupation: null };
     const text = generateLineText(event, baseParticipants);
-    expect(text).not.toContain("💼");
+    expect(text).not.toContain("対象:");
   });
 
   // LINE-008: 金額のカンマ区切り
@@ -81,14 +85,17 @@ describe("generateLineText", () => {
     const text = generateLineText(baseEvent, baseParticipants);
     const lines = text.split("\n");
 
-    expect(lines[0]).toMatch(/^📅/);
-    expect(lines[1]).toMatch(/^⏰/);
-    expect(lines[2]).toMatch(/^📍/);
-    expect(lines[3]).toMatch(/^👫/);
-    expect(lines[4]).toMatch(/^💰/);
-    expect(lines[5]).toMatch(/^🎯/);
-    expect(lines[6]).toMatch(/^💼/);
-    expect(lines[7]).toMatch(/^✅/);
+    expect(lines[0]).toBe("飲み会のお知らせ");
+    expect(lines[1]).toBe("");
+    expect(lines[2]).toContain("2025年3月15日");
+    expect(lines[3]).toContain("19:00〜");
+    expect(lines[4]).toContain("渋谷 / ダイニングバーABC");
+    expect(lines[5]).toBe("https://maps.google.com/example");
+    expect(lines[6]).toContain("男性5名");
+    expect(lines[7]).toContain("男性 6,000円");
+    expect(lines[8]).toContain("テーマ:");
+    expect(lines[9]).toContain("対象:");
+    expect(lines[10]).toContain("残枠:");
   });
 
   // LINE-010: 参加費0円
@@ -102,5 +109,24 @@ describe("generateLineText", () => {
   it("LINE-011: 定員超過の場合「満席」と表示される", () => {
     const text = generateLineText(baseEvent, { maleCount: 7, femaleCount: 3 });
     expect(text).toContain("男性満席");
+  });
+
+  // LINE-012: mapUrlがnullの場合URL行なし
+  it("LINE-012: mapUrlがnullの場合URL行が出力されない", () => {
+    const event = { ...baseEvent, mapUrl: null };
+    const text = generateLineText(event, baseParticipants);
+    expect(text).not.toContain("https://");
+    // 会場行の次が人数行であること
+    const lines = text.split("\n");
+    const venueIndex = lines.findIndex((l) => l.includes("渋谷 / ダイニングバーABC"));
+    expect(lines[venueIndex + 1]).toContain("男性5名");
+  });
+
+  // LINE-013: mapUrlがある場合、会場行の直後にURL行
+  it("LINE-013: mapUrlが設定されている場合会場行の直後にURLが出力される", () => {
+    const text = generateLineText(baseEvent, baseParticipants);
+    const lines = text.split("\n");
+    const venueIndex = lines.findIndex((l) => l.includes("渋谷 / ダイニングバーABC"));
+    expect(lines[venueIndex + 1]).toBe("https://maps.google.com/example");
   });
 });


### PR DESCRIPTION
## 概要

LINE募集メッセージのフォーマットを改良しました。

Closes #6

## 変更内容

- メッセージ先頭に「飲み会のお知らせ」タイトルを追加
- 全行から絵文字プレフィックス（📅⏰📍👫💰🎯💼✅）を削除し、シンプルな表記に変更
- `generateLineText()` に `mapUrl` 引数を追加し、会場行の直後に地図URLを表示
- テストケース13件を新フォーマットに更新（mapUrl有無のテスト2件を新規追加）

## 変更ファイル

- `src/lib/line-text.ts` - メッセージ生成ロジックの修正
- `src/components/schedule/line-text-dialog.tsx` - Props型にmapUrl追加
- `src/components/schedule/schedule-table.tsx` - mapUrlの受け渡し追加
- `tests/unit/line-text.test.ts` - テストケースの更新・追加

## テスト計画

- [x] ユニットテスト13件全PASS
- [x] TypeScript型チェックエラーなし
- [x] ESLint警告・エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)